### PR TITLE
project url added

### DIFF
--- a/widget/bgplayjs-main-widget.js
+++ b/widget/bgplayjs-main-widget.js
@@ -8,7 +8,7 @@
  * See the file LICENSE.txt for copying permission.
  */
 
-BGPLAY_PROJECT_URL = BGPLAY_PROJECT_URL || "";
+BGPLAY_PROJECT_URL = "https://cdn.jsdelivr.net/gh/InternetHealthReport/bgplay/" || "";
 
 BGPLAY_WIDGET_URL = BGPLAY_PROJECT_URL + "widget/";
 BGPLAY_MODEL_URL = BGPLAY_PROJECT_URL + "model/";


### PR DESCRIPTION
Added project URL in  `bgplayjs-main-widget.js`

Firstly I thought  to add rawcontent URL but it didn't work as the service is down
after some research I found jsdelivr 
it's a free CDN for open-source projects

So, this CDN service will be good for us or we can host the code on some other service.

After this merge at frontend, we can use this library through the CDN URL 

`https://cdn.jsdelivr.net/gh/InternetHealthReport/bgplay/widget/bgplayjs-main-widget.js`

Given in docs
`<script src="https://bgplay.massimocandela.com/bgplay/widget/bgplayjs-main-widget.js"></script>`